### PR TITLE
The GetTaxonHistory endpoint now returns separate taxa and releases.

### DIFF
--- a/ictv_web_api/src/Plugin/rest/resource/GetTaxonHistory.php
+++ b/ictv_web_api/src/Plugin/rest/resource/GetTaxonHistory.php
@@ -58,33 +58,35 @@ class GetTaxonHistory extends ResourceBase {
 
   public function get(Request $request): ResourceResponse {
     
-    // msl_release?
-    $msl = $request->get('msl_release');
-    $currentMSL = (is_numeric($msl) && (int)$msl > 0) ? (int)$msl : NULL;
+      // Get and validate the input parameters.
+      $testInt = $request->get("currentMSL");
+      $currentMSL = (is_numeric($testInt) && (int)$testInt > 0) ? (int)$testInt : NULL;
 
-    // taxnode_id required
-    $tid = $request->get('taxnode_id');
-    if (!is_numeric($tid)) {
-      throw new BadRequestHttpException("Invalid or missing taxnode_id");
-    }
-    $tid = (int)$tid;
+      $testInt = $request->get("ictvID");
+      $ictvID = (is_numeric($testInt) && (int)$testInt > 0) ? (int)$testInt : NULL;
 
-    // delegate to helper
-    $result = TaxonReleaseHistory::fetch(
-      $this->connection,
-      $currentMSL,
-      $tid
-    );
+      $testInt = $request->get("MSL");
+      $MSL = (is_numeric($testInt) && (int)$testInt > 0) ? (int)$testInt : NULL;
 
-    $response = new ResourceResponse($result);
-    $response->headers->set('Access-Control-Allow-Origin', '*');
-    $response->addCacheableDependency(['#cache' => ['max-age' => 0]]);
-    return $response;
+      $testInt = $request->get("taxNodeID");
+      $taxNodeID = (is_numeric($testInt) && (int)$testInt > 0) ? (int)$testInt : NULL;
 
-    // return (new ResourceResponse($result))
-    //   ->addCacheableDependency(['#cache' => ['max-age' => 0]])
-    //   ->headers->set('Access-Control-Allow-Origin','*');
-  }
+      $taxonName = $request->get("taxonName");
+
+      $testInt = $request->get("vmrID");
+      $vmrID = (is_numeric($testInt) && (int)$testInt > 0) ? (int)$testInt : NULL;
+
+      // DEBUGGING
+      \Drupal::logger('ictv_web_api')->notice("currentMSL = ".$currentMSL.", taxNodeID = ".$taxNodeID);
+
+      // Get the taxa and releases associated with the input parameters.
+      $result = TaxonHistory::fetch($this->connection, $currentMSL, $ictvID, $MSL, $taxNodeID, $taxonName, $vmrID);
+
+      $response = new ResourceResponse($result);
+      $response->headers->set('Access-Control-Allow-Origin', '*');
+      $response->addCacheableDependency(['#cache' => ['max-age' => 0]]);
+      return $response;
+   }
 
   /**
   * {@inheritdoc}

--- a/ictv_web_api/src/Plugin/rest/resource/models/HistoricalRelease.php
+++ b/ictv_web_api/src/Plugin/rest/resource/models/HistoricalRelease.php
@@ -1,0 +1,29 @@
+<?php
+namespace Drupal\ictv_web_api\Plugin\rest\resource\models;
+
+class HistoricalRelease {
+   
+   public ?string $releaseRankNames;
+   public ?string $releaseTitle;
+   public ?string $releaseYear;
+
+ 
+   public static function fromArray(array $d): self {
+
+      $o = new self();
+
+      $o->releaseRankNames = $d['release_rank_names'] ?? null;
+      $o->releaseTitle     = $d['release_title'] ?? null;
+      $o->releaseYear      = $d['release_year'] ?? null;
+
+      return $o;
+   }
+
+   public function normalize(): array {
+      return [
+         'releaseRankNames' => $this->releaseRankNames,
+         'releaseTitle'     => $this->releaseTitle,
+         'releaseYear'      => $this->releaseYear,
+      ];
+   }
+}

--- a/ictv_web_api/src/Plugin/rest/resource/models/HistoricalTaxon.php
+++ b/ictv_web_api/src/Plugin/rest/resource/models/HistoricalTaxon.php
@@ -1,9 +1,8 @@
 <?php
 namespace Drupal\ictv_web_api\Plugin\rest\resource\models;
 
-class TaxonAndRelease {
+class HistoricalTaxon {
    
-   // Taxon
    public ?int $ictvID;
    public int $isDeleted;
    public int $isDemoted;
@@ -27,17 +26,11 @@ class TaxonAndRelease {
    public ?string $prevProposal;
    public int $taxnodeID;
 
-   // Release
-   public ?string $releaseRankNames;
-   public ?string $releaseTitle;
-   public ?string $releaseYear;
-
  
    public static function fromArray(array $d): self {
 
       $o = new self();
 
-      // Taxon
       $o->ictvID         = isset($d['ictv_id']) ? (int)$d['ictv_id'] : null;
       $o->isDeleted      = isset($d['is_deleted']) ? (int)$d['is_deleted'] : 0;
       $o->isDemoted      = isset($d['is_demoted']) ? (int)$d['is_demoted'] : 0;
@@ -61,18 +54,11 @@ class TaxonAndRelease {
       $o->prevProposal   = $d['prev_proposal'] ?? null;
       $o->taxnodeID      = isset($d['taxnode_id']) ? (int)$d['taxnode_id'] : 0;
 
-      // Release
-      $o->releaseRankNames = $d['release_rank_names'] ?? null;
-      $o->releaseTitle     = $d['release_title'] ?? null;
-      $o->releaseYear      = $d['release_year'] ?? null;
-
       return $o;
    }
 
    public function normalize(): array {
       return [
-         
-         // Taxon
          'ictvID'         => $this->ictvID,
          'isDeleted'      => $this->isDeleted == 1,
          'isDemoted'      => $this->isDemoted == 1,
@@ -94,12 +80,7 @@ class TaxonAndRelease {
          'prevParentRank' => $this->prevParentRank,
          'prevParentName' => $this->prevParentName,
          'prevProposal'   => $this->prevProposal,
-         'taxnodeID'      => $this->taxnodeID,
-
-         // Release
-         'releaseRankNames' => $this->releaseRankNames,
-         'releaseTitle'     => $this->releaseTitle,
-         'releaseYear'      => $this->releaseYear,
+         'taxnodeID'      => $this->taxnodeID
       ];
    }
 }

--- a/ictv_web_api/src/helpers/TaxonHistory.php
+++ b/ictv_web_api/src/helpers/TaxonHistory.php
@@ -3,7 +3,8 @@
 namespace Drupal\ictv_web_api\helpers;
 
 use Drupal\Core\Database\Connection;
-use Drupal\ictv_web_api\Plugin\rest\resource\models\TaxonAndRelease;
+use Drupal\ictv_web_api\Plugin\rest\resource\models\HistoricalRelease;
+use Drupal\ictv_web_api\Plugin\rest\resource\models\HistoricalTaxon;
 
 
 class TaxonHistory {
@@ -39,7 +40,8 @@ class TaxonHistory {
    public static function fetch(Connection $connection, int $currentMSL, ?int $ictvID, ?int $MSL, ?int $taxNodeID, ?string $taxonName, ?int $vmrID): array {
 
       $messages = '';
-      $results = [];
+      $releases = [];
+      $taxa = [];
 
       // Call the stored procedure
       $sql = 'CALL GetTaxonHistory(:currentMSL, :ictvID, :MSL, :taxNodeID, :taxonName, :vmrID)';
@@ -58,17 +60,29 @@ class TaxonHistory {
       catch (\Exception $e) {
          return [
             "messages" => $e->getMessage(),
-            "results" => []
+            "releases" => [],
+            "taxa"     => []
          ];
       }
 
+      $previousYear = NULL;
+
       foreach ($rows as $r) {
-         $results.push(TaxonAndRelease::fromArray($r)->normalize());
+
+         // Add the taxon to the taxa array.
+         $taxa.push(HistoricalTaxon::fromArray($r)->normalize());
+
+         // If this is a release we haven't encountered, add it to the release array.
+         if ($r['release_year'] != $previousYear) {
+            $releases.push(HistoricalRelease::fromArray($r)->normalize());
+            $previousYear = $r['release_year'];
+         }
       }
 
       return [
          "messages" => $messages,
-         "results" => $results
+         "releases" => $releases,
+         "taxa" => $taxa
       ];
    }
 }


### PR DESCRIPTION
- Split TaxonAndRelease class into HistoricalTaxon and HistoricalRelease.
- Separating row data from GetTaxonHistory into arrays of releases and taxa.