### PR TITLE
SeqSearch and Taxon History updates

### DIFF
--- a/ictv_seqsearch_service/src/Plugin/rest/resource/Common.php
+++ b/ictv_seqsearch_service/src/Plugin/rest/resource/Common.php
@@ -21,6 +21,9 @@ class Common {
          return null;
       }
 
+      // TODO: This will be unnecessary when the output folder is removed from the JSON values.
+      if (str_starts_with($filename, "tax_out/")) { $filename = substr($filename, strlen("tax_out/"));  }
+
       // Has the file already been compressed?
       if (str_ends_with($filename, ".gz")) {
          \Drupal::logger(Common::$MODULE_NAME)->error("File ".$filePath.$filename." is already compressed.");
@@ -76,6 +79,9 @@ class Common {
       $handle = null;
       $fileData = null;
    
+      // TODO: This will be unnecessary when the output folder is removed from the JSON values.
+      if (str_starts_with($filename, "tax_out/")) { $filename = substr($filename, strlen("tax_out/"));  }
+      
       if (!str_ends_with($filePath, '/')) { $filePath = $filePath.'/'; }
 
       // Concatenate the path and filename.
@@ -84,6 +90,10 @@ class Common {
       try {
          // Open the file and read its contents.
          $handle = fopen($filePathAndName, "r");
+         if ($handle === false) {
+            \Drupal::logger(Common::$MODULE_NAME)->error("Unable to open file ".$filePathAndName);
+            return null;
+         }
          $fileData = fread($handle, filesize($filePathAndName));
    
       } catch (\Exception $e) {

--- a/ictv_seqsearch_service/src/Plugin/rest/resource/SeqSearchJob.php
+++ b/ictv_seqsearch_service/src/Plugin/rest/resource/SeqSearchJob.php
@@ -32,6 +32,9 @@ class SeqSearchJob {
          $csvFilename = $result["blast_csv"];
          if (!Utils::isNullOrEmpty($csvFilename)) { 
             
+            // TODO: This will be unnecessary when the output folder is removed from the JSON values.
+            if (str_starts_with($csvFilename, "tax_out/")) { $csvFilename = substr($csvFilename, strlen("tax_out/"));  }
+
             // Open the compressed version of the CSV file.
             $csvFilename = $csvFilename.".gz";
 
@@ -45,6 +48,9 @@ class SeqSearchJob {
          $htmlFilename = $result["blast_html"];
          if (!Utils::isNullOrEmpty($htmlFilename)) { 
             
+            // TODO: This will be unnecessary when the output folder is removed from the JSON values.
+            if (str_starts_with($htmlFilename, "tax_out/")) { $htmlFilename = substr($htmlFilename, strlen("tax_out/"));  }
+
             // Open the compressed version of the CSV file.
             $htmlFilename = $htmlFilename.".gz";
 
@@ -84,6 +90,9 @@ class SeqSearchJob {
          $csvFilename = $result["blast_csv"];
          if (!Utils::isNullOrEmpty($csvFilename)) {
 
+            // TODO: This will be unnecessary when the output folder is removed from the JSON values.
+            if (str_starts_with($csvFilename, "tax_out/")) { $csvFilename = substr($csvFilename, strlen("tax_out/"));  }
+
             $encodedData = null;
 
             // Compress the CSV file, create a new compressed file, and return the compressed data.
@@ -104,6 +113,9 @@ class SeqSearchJob {
          if (!Utils::isNullOrEmpty($htmlFilename)) { 
 
             $encodedData = null;
+
+            // TODO: This will be unnecessary when the output folder is removed from the JSON values.
+            if (str_starts_with($htmlFilename, "tax_out/")) { $htmlFilename = substr($htmlFilename, strlen("tax_out/"));  }
 
             // Compress the HTML file, create a new compressed file, and return the compressed data.
             $compressedData = Common::createCompressedFile($htmlFilename, $outputPath); 

--- a/ictv_seqsearch_service/src/Plugin/rest/resource/UploadSequences.php
+++ b/ictv_seqsearch_service/src/Plugin/rest/resource/UploadSequences.php
@@ -292,6 +292,7 @@ class UploadSequences extends ResourceBase {
             $contents = $file["contents"];
             if (Utils::isNullOrEmpty($contents)) { throw new BadRequestHttpException("Invalid file contents"); }
 
+            /*
             $fileStartIndex = stripos($contents, ",");
             if ($fileStartIndex < 0) { throw new BadRequestHttpException("Invalid data URL in sequence file"); }
 
@@ -301,13 +302,14 @@ class UploadSequences extends ResourceBase {
             // TODO: Consider gzipping the binary data in the browser and using gzuncompress() here.
             // Decode the file contents from base64.
             $binaryData = base64_decode($base64Data);
+            */
 
             // TODO: Is this really binary data? Can we parse it as text?
             // TODO: This would be a good place to validate the sequence data to make sure the number of sequences 
             // submitted is less than or equal to $MAX_SEQUENCE_COUNT.
 
             // Create the sequence file in the job directory using the data provided.
-            $fileID = $this->jobService->createInputFile($binaryData, $filename, $jobPath);
+            $fileID = $this->jobService->createInputFile($contents, $filename, $jobPath);
 
             // Create a job file record.
             $jobFileUID = $this->jobService->createJobFile($this->connection, $filename, $jobID, $uploadOrder);

--- a/ictv_web_api/src/Plugin/rest/resource/GetTaxonHistory.php
+++ b/ictv_web_api/src/Plugin/rest/resource/GetTaxonHistory.php
@@ -23,7 +23,8 @@ use Drupal\ictv_web_api\helpers\TaxonReleaseHistory;
   *   id = "get_taxon_history",
   *   label = @Translation("Get Taxon History"),
   *   uri_paths = {
-  *     "canonical" = "/api/get-taxon-history"
+  *     "canonical" = "/api/get-taxon-history-test",
+  *     "create" = "/api/get-taxon-history-test"
   *   }
   * )
   */

--- a/sql/TaxonomyHistory/GetTaxonHistory.sql
+++ b/sql/TaxonomyHistory/GetTaxonHistory.sql
@@ -16,7 +16,7 @@ CREATE PROCEDURE GetTaxonHistory(
    IN `MSL` INT,
 
    -- The taxnode ID of the taxon to query.
-   IN `taxNodeID` INT,
+   OUT `taxNodeID` INT,
 
    -- The taxon name to query.
    IN `taxonName` VARCHAR(300),

--- a/ui/src/components/SequenceSearch/BlastPanel.ts
+++ b/ui/src/components/SequenceSearch/BlastPanel.ts
@@ -1,0 +1,120 @@
+
+import { AlertBuilder } from "../../helpers/AlertBuilder";
+import { ButtonClass, Constants, Icon, PanelKey } from "./Common";
+import { decode } from "base64-arraybuffer";
+import { ISeqSearchPanel } from "./ISeqSearchPanel";
+import { SequenceSearch } from "./SequenceSearch";
+import { SequenceSearchService } from "../../services/SequenceSearchService";
+import * as pako from "pako";
+
+
+export class BlastPanel implements ISeqSearchPanel {
+
+   // DOM elements
+   elements: {
+      container: HTMLElement
+   }
+
+   // The parent page
+   parent: SequenceSearch = null;
+
+
+   // C-tor
+   constructor(parent_: SequenceSearch) {
+
+      if (!parent_) { throw new Error("Invalid parent parameter"); }
+      this.parent = parent_;
+
+
+
+   }
+
+
+   // Download the BLAST CSV data for a specific result.
+   async downloadCSV(index_: number) {
+
+      // Get the result with the specified index.
+      const result = this.parent.job.data.results[index_];
+      if (!result || !result.csv_file || !result.blast_csv) {
+         await AlertBuilder.displayError("No CSV file is available for download.");
+         return;
+      }
+
+      // Decode the base64-encoded CSV file and decompress it.
+      const arrayBuffer: ArrayBuffer = pako.inflate(decode(result.csv_file));
+      if (!arrayBuffer || arrayBuffer.byteLength === 0) {
+         await AlertBuilder.displayError("The CSV file is invalid: It may be empty or corrupted.");
+         return;
+      }
+
+      // Associate the ArrayBuffer with a Blob, create a download link, and trigger the download.
+      const link = document.createElement('a')
+      link.href = URL.createObjectURL(new Blob(
+         [ arrayBuffer ],
+         { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }
+      ))
+      link.download = result.blast_csv;
+      link.click();
+
+      return;
+   }
+
+
+   display() {
+
+      console.debug("Displaying the BLAST panel");
+   }
+
+   async handleResultsClick(event_) {
+
+      if (event_.target.tagName !== "BUTTON") { return; }
+
+      const button = event_.target as HTMLButtonElement;
+
+      // Get and validate the button's data index attribute.
+      let strDataIndex = button.getAttribute("data-index");
+      const dataIndex = parseInt(strDataIndex);
+      if (dataIndex < 0 || dataIndex > this.parent.job.data.results.length) {
+         await AlertBuilder.displayError(`Invalid result index: ${dataIndex}`);
+         return;
+      }
+
+      // The button's class determines which action to take.
+      /*if (button.classList.contains(ButtonClass.copyURL)) {
+         await this.copyJobURL();
+
+      } else*/ if (button.classList.contains(ButtonClass.downloadCSV)) {
+         await this.downloadCSV(dataIndex);
+
+      } else if (button.classList.contains(ButtonClass.viewHTML)) {
+         await this.viewHTML(dataIndex);
+      }
+     
+      return;
+   }
+
+   unload() {
+
+
+   }
+
+   // Display the BLAST HTML data for a specific result.
+   async viewHTML(index_: number) {
+
+      // Get the result with the specified index.
+      const result = this.parent.job.data.results[index_];
+
+      // Open a new tab/window and populate it with the contents of the BLAST HTML file.
+      const blastWindow = window.open("", "_blank");
+
+      // Decode the base64-encoded HTML file and decompress it.
+      const html = pako.inflate(decode(result.html_file), { to: 'string' });
+      blastWindow.document.writeln(html);
+
+      // Remove the extension from the file name and use it as the window's title.
+      blastWindow.document.title = result.blast_html.replace(".html", "");
+
+      return;
+   }
+
+}

--- a/ui/src/components/SequenceSearch/Common.ts
+++ b/ui/src/components/SequenceSearch/Common.ts
@@ -1,0 +1,39 @@
+
+
+// CSS class names for buttons.
+export enum ButtonClass {
+   cancel = "cancel-button",
+   copyURL = "copy-url-button",
+   downloadCSV = "download-csv-button",
+   upload = "upload-button",
+   viewHTML = "view-html-button"
+}
+
+export const Constants = {
+
+   // The maximum number of sequences that can be uploaded.
+   MAX_SEQUENCE_COUNT: 64,
+
+   NO_EMAIL: "NO_EMAIL"
+}
+
+export enum Icon {
+   browse = `<i class=\"fa fa-file\"></i>`,
+   cancel = `<i class="fa-solid fa-xmark"></i>`,
+   chevronDown = `<i class=\"fa fa-chevron-circle-down expanded\"></i>`,
+   chevronRight = `<i class=\"fa fa-chevron-circle-right collapsed\"></i>`,
+   close = `<i class=\"fa fa-xmark\"></i>`,
+   copy = `<i class=\"fa-regular fa-clipboard\"></i>`,
+   csv = `<i class="fa-regular fa-file-csv"></i>`,
+   download = `<i class=\"fa fa-download\"></i>`,
+   html = `<i class="fa-regular fa-file-lines"></i>`,
+   lineageDelimiter = `<i class="fa-solid fa-chevron-right"></i>`,
+   upload = `<i class=\"fa fa-upload\"></i>`
+}
+
+export enum PanelKey {
+   blastPanel = "blastPanel",
+   jobPanel = "jobPanel",
+   uploadPanel = "uploadPanel"
+}
+

--- a/ui/src/components/SequenceSearch/IBlastHit.ts
+++ b/ui/src/components/SequenceSearch/IBlastHit.ts
@@ -10,19 +10,19 @@ export interface IBlastHit {
    sseqid_accession: string;
    sseqid_lineage: {
       realm: string;
-      family: string;
-      subfamily: string;
-      phylum: string;
-      class: string;
-      order: string;
-      genus: string;
-      species: string;
+      subrealm: string;
       kingdom: string;
       subkingdom: string;
+      phylum: string;
       subphylum: string;
-      subrealm: string;
+      class: string;
       subclass: string;
+      order: string;
       suborder: string;
+      family: string;
+      subfamily: string;
+      genus: string;
       subgenus: string;
+      species: string;
    }
 }

--- a/ui/src/components/SequenceSearch/ISeqSearchPanel.ts
+++ b/ui/src/components/SequenceSearch/ISeqSearchPanel.ts
@@ -1,0 +1,9 @@
+
+import { SequenceSearch } from './SequenceSearch';
+
+export interface ISeqSearchPanel {
+
+   display();
+
+   unload();
+}

--- a/ui/src/components/SequenceSearch/JobPanel.ts
+++ b/ui/src/components/SequenceSearch/JobPanel.ts
@@ -1,0 +1,208 @@
+
+import { AlertBuilder } from "../../helpers/AlertBuilder";
+import { ButtonClass, Constants, Icon, PanelKey } from "./Common";
+import { decode } from "base64-arraybuffer";
+import { ISearchResult } from "./ISearchResult";
+import { ISeqSearchJob } from "./ISeqSearchJob";
+import { ISeqSearchPanel } from "./ISeqSearchPanel";
+import { SequenceSearch } from "./SequenceSearch";
+import { SequenceSearchService } from "../../services/SequenceSearchService";
+import * as pako from "pako";
+
+
+export class JobPanel implements ISeqSearchPanel {
+   
+   // DOM elements
+   elements: {
+      container: HTMLElement,
+      copyIdButton: HTMLButtonElement,
+      jobName: HTMLInputElement,
+      jobNameLabel: HTMLElement
+   }
+
+   job: ISeqSearchJob = null;
+
+   // The URL that can be used to return and view the job data.
+   jobURL: string = null;
+
+   // The parent page
+   parent: SequenceSearch = null;
+
+
+
+   // C-tor
+   constructor(parent_: SequenceSearch) {
+
+      if (!parent_) { throw new Error("Invalid parent parameter"); }
+      this.parent = parent_;
+
+      this.elements = {
+         container: null,
+         copyIdButton: null,
+         jobName: null,
+         jobNameLabel: null
+      }
+
+   }
+
+   async copyJobURL() {
+
+      // Copy the URL to the clipboard.
+      await navigator.clipboard.writeText(this.jobURL);
+
+      // Display a success message.
+      return await AlertBuilder.displaySuccess("The URL has been copied to your clipboard. You can now bookmark it or paste it into a document for future reference.");
+   }
+
+   display() {
+
+      // Create a local copy of the parent's job container Element.
+      this.elements.container = this.parent.elements.jobContainer;
+
+      // Make a local copy of the job data.
+      this.job = this.parent.job;
+
+      if (!this.job || !this.job) {
+         this.elements.container.innerHTML = `<div class="no-results">No results</div>`;
+         return;
+      }
+
+      // Clear any existing content in the container.
+      this.elements.container.innerHTML = "";
+
+      //----------------------------------------------------------------------------------------------------------------
+      // Create the URL that can be used to view the job data.
+      //----------------------------------------------------------------------------------------------------------------
+      this.jobURL = window.location.href;
+
+      // TODO: Get rid of this line soon!!!
+      this.jobURL = this.jobURL.replace("test.ictv.global", "ictv.global");
+
+      // Remove any existing query string parameters.
+      let qIndex = this.jobURL.indexOf("?");
+      if (qIndex > -1) { this.jobURL = this.jobURL.substring(0, qIndex); }
+
+      this.jobURL += `?job=${this.job.uid}`;
+
+      //----------------------------------------------------------------------------------------------------------------
+      // Generate HTML for the search results.
+      //----------------------------------------------------------------------------------------------------------------
+      let resultsHTML = "";
+
+      if (Array.isArray(this.parent.job.data.results) && this.parent.job.data.results.length > 0) {
+
+         this.job.data.results.forEach((result_: ISearchResult, resultIndex_: number) => {
+            resultsHTML += this.createSearchResult(result_, resultIndex_);
+         })
+
+         if (resultsHTML.length > 0) {
+            resultsHTML = 
+               `<table class="results-table">
+                  <thead>
+                     <tr class="header-row">
+                        <th>Input file</th>
+                        <th>Status</th>
+                        <th>Hits</th>
+                        <th></th>
+                     </tr>
+                  </thead>
+                  <tbody>${resultsHTML}</tbody>
+               </table>`;
+         }  
+      } else {
+         resultsHTML = `<div class="no-results">No results</div>`;
+      }
+
+      //----------------------------------------------------------------------------------------------------------------
+      // Generate the HTML for the job
+      //----------------------------------------------------------------------------------------------------------------
+      let html = 
+         `<hr />
+         <div class="results">
+            <div class="results-title">Your results</div>
+            <div class="job-details">
+               <div class="job-table">
+                  <div class="job-row">
+                     <label>Job name:</label>
+                     <div class="job-value">${this.job.name || "(none)"}</div>
+                  </div>
+                  <div class="job-row">
+                     <label>Job status:</label>
+                     <div class="job-value">${this.job.status}</div>
+                  </div>
+                  <div class="job-row">
+                     <label>Program and version:</label>
+                     <div class="job-value">${this.job.data.program_name} (version ${this.job.data.version})</div>
+                  </div>
+                  <div class="job-row">
+                     <label>Database:</label>
+                     <div class="job-value">${this.job.data.database_name}</div>
+                  </div>
+               </div>
+               <div class="link-panel">
+                  <div class="instructions">You can view these results again using the following URL:</div>
+                  <div class="controls">
+                     <a href="${this.jobURL}" target="_blank">${this.jobURL}</a> 
+                     <button class="btn ${ButtonClass.copyURL}">${Icon.copy} Copy to clipboard</button>
+                  </div>
+               </div>
+            </div>
+            <hr />
+            <div class="blast-hits-title">Results</div>
+            <div class="search-results">${resultsHTML}</div>
+         </div>`;
+
+      this.elements.container.innerHTML = html;
+
+      return;
+   }
+
+   // Create HTML for a search result row.
+   createSearchResult(result_: ISearchResult, index_: number): string {
+
+      let html = `<tr>
+         <td>${result_.input_file}</td>
+         <td>${result_.status}</td>
+         <td>${Array.isArray(result_.hits) ? result_.hits.length : 0}</td>            
+         <td>
+            <button class="btn ${ButtonClass.viewHTML} has-tooltip" 
+               data-index="${index_}" 
+               data-tippy-content="Click to view the HTML results (${result_.blast_html})"
+            >${Icon.html} View HTML results</button>
+            <button class="btn ${ButtonClass.downloadCSV} has-tooltip" 
+               data-index="${index_}"
+               data-tippy-content="Click to download the results as a CSV file (${result_.blast_csv})"
+            >${Icon.csv} Download CSV results</button>
+         </td>
+      </tr>`;
+      
+      // TODO: Where to display errors?
+      return html;
+   }
+
+   
+
+   unload() {
+
+
+   }
+
+   // Display the BLAST HTML data for a specific result.
+   async viewHTML(index_: number) {
+
+      // Get the result with the specified index.
+      const result = this.job.data.results[index_];
+
+      // Open a new tab/window and populate it with the contents of the BLAST HTML file.
+      const blastWindow = window.open("", "_blank");
+
+      // Decode the base64-encoded HTML file and decompress it.
+      const html = pako.inflate(decode(result.html_file), { to: 'string' });
+      blastWindow.document.writeln(html);
+
+      // Remove the extension from the file name and use it as the window's title.
+      blastWindow.document.title = result.blast_html.replace(".html", "");
+
+      return;
+   }
+}

--- a/ui/src/components/SequenceSearch/SequenceSearch.ts
+++ b/ui/src/components/SequenceSearch/SequenceSearch.ts
@@ -1,25 +1,18 @@
 
 import { AlertBuilder } from "../../helpers/AlertBuilder";
+import { BlastPanel } from "./BlastPanel";
+import { ButtonClass, Constants, Icon, PanelKey } from "./Common";
 import { decode } from "base64-arraybuffer";
 import { ISeqSearchJob } from "./ISeqSearchJob";
-import { IFileData } from "../../models/IFileData";
-import { ISearchResult } from "./ISearchResult";
+import { ISeqSearchPanel } from "./ISeqSearchPanel";
+import { JobPanel } from "./JobPanel";
 import { LookupTaxonomyRank, WebStorageKey } from "../../global/Types";
-import * as pako from "pako";
+
 import { SequenceSearchService } from "../../services/SequenceSearchService";
 import tippy from "tippy.js";
+import { UploadPanel } from "./UploadPanel";
 import { Utils } from "../../helpers/Utils";
-import { AppSettings } from "../CuratedNameManager";
 
-
-// CSS class names for buttons.
-enum ButtonClass {
-   cancel = "cancel-button",
-   copyURL = "copy-url-button",
-   downloadCSV = "download-csv-button",
-   upload = "upload-button",
-   viewHTML = "view-html-button"
-}
 
 
 export class SequenceSearch {
@@ -31,43 +24,15 @@ export class SequenceSearch {
       contactEmail: null
    }
 
-   constants = {
-      NO_EMAIL: "NO_EMAIL"
-   }
-
    // The CSS selector for the container element where the Sequence Search UI will be rendered.
    containerSelector: string = null;
 
    // DOM elements
    elements: {
-      cancelButton: HTMLButtonElement,
+      blastContainer: HTMLElement,
       container: HTMLElement,
-      copyIdButton: HTMLButtonElement,
-      fileControl: HTMLElement,
-      fileInput: HTMLInputElement,
-      fileSelection: HTMLElement,
-      fileSubmission: HTMLElement,
-      fileUploadDetails: HTMLElement,
-      jobName: HTMLInputElement,
-      jobNameLabel: HTMLElement,
-      results: HTMLElement,
-      resultsContainer: HTMLElement,
-      uploadButton: HTMLButtonElement
-   }
-
-   // Icons used on the page.
-   icons: {
-      browse: string,
-      cancel: string,
-      chevronDown: string,
-      chevronRight: string,
-      close: string,
-      copy: string,
-      csv: string,
-      download: string,
-      html: string,
-      lineageDelimiter: string,
-      upload: string
+      jobContainer: HTMLElement,
+      uploadContainer: HTMLElement
    }
 
    job: ISeqSearchJob = null;
@@ -75,11 +40,16 @@ export class SequenceSearch {
    // The current job UID (optional)
    jobUID: string = null;
    
-   // The URL that can be used to return and view the job data.
-   jobURL: string = null;
+   // Which panel is currently displayed?
+   panelKey: PanelKey = null;
 
-   // The maximum number of sequences that can be uploaded.
-   MAX_SEQUENCE_COUNT = 64;
+   panels: Map<PanelKey, ISeqSearchPanel>;
+
+   // The previous panel key
+   previousPanelKey: PanelKey = null;
+
+   // The current result index (optional)
+   resultIndex: number = null;
 
    // User information
    user: {
@@ -97,7 +67,7 @@ export class SequenceSearch {
       if (!authToken_ || authToken_.length < 1) { throw new Error("Invalid auth token in SequenceSearch"); }
       if (!contactEmail_) { throw new Error("Invalid contact email"); }
       if (!containerSelector_ || containerSelector_.length < 1) { throw new Error("Invalid container selector in SequenceSearch"); }
-      if (!email_ || email_.length < 1) { email_ = this.constants.NO_EMAIL; }
+      if (!email_ || email_.length < 1) { email_ = Constants.NO_EMAIL; }
       if (!name_ || name_.length < 1) { name_ = "Anonymous user"; }
       userUID_ = Utils.safeTrim(userUID_);
 
@@ -113,57 +83,27 @@ export class SequenceSearch {
       }
 
       this.elements = {
-         cancelButton: null,
          container: null,
-         copyIdButton: null,
-         fileControl: null,
-         fileInput: null,
-         fileSelection: null,
-         fileSubmission: null,
-         fileUploadDetails: null,
-         jobName: null,
-         jobNameLabel: null,
-         results: null,
-         resultsContainer: null,
-         uploadButton: null
+         jobContainer: null,
+         blastContainer: null,
+         uploadContainer: null
       }
 
-      this.icons = {
-         browse: `<i class=\"fa fa-file\"></i>`,
-         cancel: `<i class="fa-solid fa-xmark"></i>`,
-         chevronDown: `<i class=\"fa fa-chevron-circle-down expanded\"></i>`,
-         chevronRight: `<i class=\"fa fa-chevron-circle-right collapsed\"></i>`,
-         close: `<i class=\"fa fa-xmark\"></i>`,
-         copy: `<i class=\"fa-regular fa-clipboard\"></i>`,
-         csv: `<i class="fa-regular fa-file-csv"></i>`,
-         download: `<i class=\"fa fa-download\"></i>`,
-         html: `<i class="fa-regular fa-file-lines"></i>`,
-         lineageDelimiter: `<i class="fa-solid fa-chevron-right"></i>`,
-         upload: `<i class=\"fa fa-upload\"></i>`
-      }
+      this.panels = new Map<PanelKey, ISeqSearchPanel>();
    }
 
    
-   async copyJobURL() {
-
-      // Copy the URL to the clipboard.
-      await navigator.clipboard.writeText(this.jobURL);
-
-      // Display a success message.
-      return await AlertBuilder.displaySuccess("The URL has been copied to your clipboard. You can now bookmark it or paste it into a document for future reference.");
-   }
-
-
-   async displayJob() {
+   /*async displayJob() {
 
       if (!this.job || !this.job.data || !this.job.data.results) {
-         this.elements.resultsContainer.innerHTML = "No results";
+         this.elements.blastContainer.innerHTML = "No results";
          return;
       }
 
       // Clear any existing content in the results container.
-      this.elements.resultsContainer.innerHTML = "";
+      this.elements.blastContainer.innerHTML = "";
 
+      
       //----------------------------------------------------------------------------------------------------------------
       // Create the URL that can be used to view the job data.
       //----------------------------------------------------------------------------------------------------------------
@@ -178,6 +118,7 @@ export class SequenceSearch {
 
       this.jobURL += `?job=${this.job.uid}`;
 
+      
       //----------------------------------------------------------------------------------------------------------------
       // Generate the HTML for the job results.
       //----------------------------------------------------------------------------------------------------------------
@@ -196,7 +137,7 @@ export class SequenceSearch {
          let isFirstRank = true;
          let lineage = "";
          
-         /*
+         
          // Populate the lineage to be displayed.
          if (!result_.sseqid_lineage) {
             lineage = "No lineage";
@@ -277,9 +218,9 @@ export class SequenceSearch {
                      data-tippy-content="Click to download the results as a CSV file (${result_.blast_csv})"
                   >${this.icons.csv} Download CSV results</button>
                </div>  
-            </div>`; */
+            </div>`; 
 
-         resultsHTML += resultHTML;
+         //resultsHTML += resultHTML;
       })
    
       
@@ -307,15 +248,11 @@ export class SequenceSearch {
                   </div>
                   <div class="job-row">
                      <label>Program and version:</label>
-                     <div class="job-value">${this.job.data.program_name} (version ${this.job.data.program_version})</div>
+                     <div class="job-value">${this.job.data.program_name} (version ${this.job.data.version})</div>
                   </div>
                   <div class="job-row">
                      <label>Database:</label>
                      <div class="job-value">${this.job.data.database_title}</div>
-                  </div>
-                  <div class="job-row">
-                     <label>Database size:</label>
-                     <div class="job-value">${this.job.data.database_size}</div>
                   </div>
                   <div class="job-row">
                      <label>Input file${filesS}:</label>
@@ -346,40 +283,9 @@ export class SequenceSearch {
 
       // Initialize tippy tooltips for the buttons
       tippy(".has-tooltip");
-
+      
       return;
-   }
-
-
-   // Download the BLAST CSV data for a specific result.
-   async downloadCSV(index_: number) {
-
-      // Get the result with the specified index.
-      const result = this.job.data.results[index_];
-      if (!result || !result.csv_file || !result.blast_csv) {
-         await AlertBuilder.displayError("No CSV file is available for download.");
-         return;
-      }
-
-      // Decode the base64-encoded CSV file and decompress it.
-      const arrayBuffer: ArrayBuffer = pako.inflate(decode(result.csv_file));
-      if (!arrayBuffer || arrayBuffer.byteLength === 0) {
-         await AlertBuilder.displayError("The CSV file is invalid: It may be empty or corrupted.");
-         return;
-      }
-
-      // Associate the ArrayBuffer with a Blob, create a download link, and trigger the download.
-      const link = document.createElement('a')
-      link.href = URL.createObjectURL(new Blob(
-         [ arrayBuffer ],
-         { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }
-      ))
-      link.download = result.blast_csv;
-      link.click();
-
-      return;
-   }
-
+   }*/
 
    // Generate a universally unique identifier (UUID).
    generateUUID() {
@@ -397,45 +303,17 @@ export class SequenceSearch {
       ).join('');
    }
 
-
    // Retrieve the job with this UID.
    async getJob() {
 
-      if (!this.jobUID) { return; }
+      if (!this.jobUID) {
+         await AlertBuilder.displayError("No job UID provided");
+         return; 
+      }
 
       this.job = await SequenceSearchService.getSearchResult(this.authToken, this.jobUID, this.user.email, this.user.uid);
       return;
    }
-
-
-   async handleResultsClick(event_) {
-
-      if (event_.target.tagName !== 'BUTTON') { return; }
-
-      const button = event_.target as HTMLButtonElement;
-
-      // Get and validate the button's data index attribute.
-      let strDataIndex = button.getAttribute("data-index");
-      const dataIndex = parseInt(strDataIndex);
-      if (dataIndex < 0 || dataIndex > this.job.data.results.length) {
-         await AlertBuilder.displayError(`Invalid result index: ${dataIndex}`);
-         return;
-      }
-
-      // The button's class determines which action to take.
-      if (button.classList.contains(ButtonClass.copyURL)) {
-         await this.copyJobURL();
-
-      } else if (button.classList.contains(ButtonClass.downloadCSV)) {
-         await this.downloadCSV(dataIndex);
-
-      } else if (button.classList.contains(ButtonClass.viewHTML)) {
-         await this.viewHTML(dataIndex);
-      }
-     
-      return;
-   }
-
 
    // Initialize the Sequence Search component.
    async initialize() {
@@ -447,142 +325,120 @@ export class SequenceSearch {
       this.elements.container = <HTMLElement>document.querySelector(this.containerSelector);
       if (!this.elements.container) { throw new Error("Invalid container Element"); }
 
-      // Format the accepted file types.
-      let fileFormats = this.config.acceptedFileTypes.join(",");
-
-      // Create HTML for the container Element.
+      // Create HTML for the container elements.
       const html = 
-         `<div class=\"upload-panel\">
-            <div class="file-selection active">
-               <div class="upload-message">Upload your FASTA sequence(s)</div>
-               <button class=\"btn file-control\">${this.icons.browse} Select file(s)</button>
-               <input type=\"file\" id=\"file_input\" multiple accept="${fileFormats}" />
-            </div>
-            <div class="file-submission">
-               <div class=\"job-name-label\">Job name</div>
-               <input type=\"text\" class=\"job-name\" placeholder=\"(optional)\" />
-               <button class=\"btn ${ButtonClass.upload}\">Submit file(s)</button>
-               <button class=\"btn ${ButtonClass.cancel}\">${this.icons.cancel} Cancel</button>
-            </div>
-         </div>
-         <div class=\"results-container\"></div>`;
+         `<div class=\"blast-container container\"></div>
+         <div class=\"job-container container\"></div>
+         <div class=\"upload-container container active\"></div>`;
 
       this.elements.container.innerHTML = html;
 
-      // Get and validate the file selection panel.
-      this.elements.fileSelection = <HTMLElement>this.elements.container.querySelector(".file-selection");
-      if (!this.elements.fileSelection) { throw new Error("Invalid file selection Element"); }
+      // The BLAST container
+      this.elements.blastContainer = this.elements.container.querySelector(".blast-container") as HTMLElement;
+      if (!this.elements.blastContainer) { throw new Error("Invalid BLAST container Element"); }
 
-      // Get and validate the file submission panel.
-      this.elements.fileSubmission = <HTMLElement>this.elements.container.querySelector(".file-submission");
-      if (!this.elements.fileSubmission) { throw new Error("Invalid file submission Element"); }  
+      // The job container
+      this.elements.jobContainer = this.elements.container.querySelector(".job-container") as HTMLElement;
+      if (!this.elements.jobContainer) { throw new Error("Invalid job container Element"); }
 
-      // Get and validate the upload button.
-      this.elements.uploadButton = <HTMLButtonElement>this.elements.container.querySelector(`.${ButtonClass.upload}`);
-      if (!this.elements.uploadButton) { throw new Error("Invalid upload button Element"); }
+      // The upload container
+      this.elements.uploadContainer = this.elements.container.querySelector(".upload-container") as HTMLElement;
+      if (!this.elements.uploadContainer) { throw new Error("Invalid upload container Element"); }
 
-      this.elements.uploadButton.addEventListener("click", () => { this.uploadSequences(); })
 
-      // Get and validate the file input Element.
-      this.elements.fileInput = <HTMLInputElement>this.elements.container.querySelector("#file_input");
-      if (!this.elements.fileInput) { throw new Error("Invalid file input Element"); }
+      // Create the panel instances.
+      this.panels.set(PanelKey.blastPanel, new BlastPanel(this));
+      this.panels.set(PanelKey.jobPanel, new JobPanel(this));
+      this.panels.set(PanelKey.uploadPanel, new UploadPanel(this));
 
-      // Handle a file selection change.
-      this.elements.fileInput.addEventListener("change", async (event_: MouseEvent) => {
-      
-         if (!this.elements.fileInput.files || this.elements.fileInput.files.length < 1) {
-               
-            // Hide the file submission panel.
-            this.elements.fileSubmission.classList.remove("active");
-            return;
-         }
-         
-         // Begin populating the upload button text.
-         let buttonText = `${this.icons.upload} Submit`;
-         
-         if (this.elements.fileInput.files.length === 1) {
-            buttonText += " file";
-         } else {
-            buttonText += ` ${this.elements.fileInput.files.length} files`;
-         }
+      // Process the query string parameters.
+      this.processParameters();
 
-         // Hide the file selection panel.
-         this.elements.fileSelection.classList.remove("active");
+      // Unload the previous panel.
+      if (this.previousPanelKey) {
+         // TODO
+      }
 
-         // Display the file submission panel.
-         this.elements.fileSubmission.classList.add("active");
+      let panel: ISeqSearchPanel = null;
 
-         // Update the upload button text.
-         this.elements.uploadButton.innerHTML = buttonText;
-      })
+      switch (this.panelKey) {
 
-      this.elements.fileControl = <HTMLElement>this.elements.container.querySelector(".file-control");
-      if (!this.elements.fileControl) { throw new Error("Invalid file control Element"); }
+         case PanelKey.blastPanel:
+            // TODO
+            console.log("Displaying BLAST panel");
+            await this.getJob();
+            break;
 
-      // Clicking on the file button will trigger a click on the file input element.
-      this.elements.fileControl.addEventListener("click", async (event_: MouseEvent) => {
-         this.elements.fileInput.click();
-      })
+         case PanelKey.jobPanel:
+            
+            console.log("Displaying job panel");
+            await this.getJob();
 
-      // The job name control and its label.
-      this.elements.jobNameLabel = <HTMLElement>this.elements.container.querySelector(".job-name-label");
-      if (!this.elements.jobNameLabel) { throw new Error("Invalid job name label Element"); }
+            // Get and validate the job panel.
+            panel = this.panels.get(PanelKey.jobPanel);
+            if (!panel) { throw new Error("Invalid job panel"); }
 
-      this.elements.jobName = <HTMLInputElement>this.elements.container.querySelector(".job-name");
-      if (!this.elements.jobName) { throw new Error("Invalid job name Element"); }
+            panel.display();
+            break;
 
-      // The cancel (submission) button
-      this.elements.cancelButton = <HTMLButtonElement>this.elements.container.querySelector(`.${ButtonClass.cancel}`);
-      if (!this.elements.cancelButton) { throw new Error("Invalid cancel button Element"); }
+         case PanelKey.uploadPanel:
+            
+            console.log("Displaying upload panel");
 
-      // Handle the cancel button click event.
-      this.elements.cancelButton.addEventListener("click", (event_: MouseEvent) => {
+            // Get and validate the upload panel.
+            panel = this.panels.get(PanelKey.uploadPanel);
+            console.debug("upload panel = ", panel);
+            
+            if (!panel) { throw new Error("Invalid upload panel"); }
+            
+            panel.display();
+            break;
 
-         // Display the file selection panel again.
-         this.elements.fileSelection.classList.add("active");
+         default:
+            return await AlertBuilder.displayError(`Unhandled panel key: ${this.panelKey}`);
+      }
 
-         // Hide the file submission panel.
-         this.elements.fileSubmission.classList.remove("active");
-
-         // Clear the file input
-         this.elements.fileInput.value = ""; 
-
-         // Clear the job name input
-         this.elements.jobName.value = ""; 
-      })
-
-      // The job panel and results body.
-      this.elements.resultsContainer = <HTMLElement>this.elements.container.querySelector(".results-container");
-      if (!this.elements.resultsContainer) { throw new Error("Invalid results container Element"); }
-
-      // Was a job UID parameter provided?
-      const urlParams = new URLSearchParams(window.location.search);
-      this.jobUID = urlParams.get("job");
-
+      /*
       // If a job UID was provided as a query string parameter, retrieve the corresponding job and display it.
       if (this.jobUID !== null) { 
          await this.getJob();
          await this.displayJob();
-      }
+      }*/
 
       return;
    }
 
+   // Look for query string parameters and use them to determine which panel to display.
+   processParameters() {
 
-   // Read the contents of a file asynchronously and return it as a base64-encoded string.
-   async readFileAsync(file_): Promise<string> {
+      // Was a job UID parameter provided?
+      const urlParams = new URLSearchParams(window.location.search);
+      
+      // Set default values
+      this.jobUID = null;
+      this.panelKey = PanelKey.uploadPanel;
+      this.resultIndex = null;
 
-      return new Promise((resolve, reject) => {
-         const reader = new FileReader();
-         reader.onload = () => {
-            resolve(<string>reader.result);
-         };
-         reader.onerror = reject;
-         reader.readAsText(file_);
-         //reader.readAsDataURL(file_);
-      })
+      // Was a job UID provided in the query string?
+      this.jobUID = urlParams.get("job");
+      if (this.jobUID) {
+
+         // Was a result index provided in the query string?
+         let strResult = Utils.safeTrim(urlParams.get("result"));
+         if (strResult) {
+            this.resultIndex = parseInt(strResult, 10);
+            if (isNaN(this.resultIndex)) { 
+               this.resultIndex = null; 
+            } else {
+               // If a result index was provided, display the BLAST panel.
+               this.panelKey = PanelKey.blastPanel;
+            }
+         } else {
+            // If no result index was provided, display the job panel.
+            this.panelKey = PanelKey.jobPanel;
+         }
+      }  
    }
-
 
    // If the user UID is empty, look for one in web storage or generate a new one.
    async setDefaultUserUID() {
@@ -607,133 +463,6 @@ export class SequenceSearch {
             localStorage.setItem(WebStorageKey.sequenceSearchUserUID, this.user.uid);
          }
       }
-
-      return;
-   }
-
-
-   // This dialog lets the user know that their files are being processed and what to expect.
-   async showInfoDialog(fileCount_: number, filenames_: string) {
-
-      let content: string;
-      let title: string;
-
-      // The message content depends on the number of files.
-      if (fileCount_ === 1) {
-         title = "Processing your sequence file";
-         content = "Your sequence file has been uploaded. Depending on the size of the file, the processing may take several minutes to copmlete.";
-
-      } else {
-         title = "Processing your sequence files";
-         content = "Your sequence files have been uploaded. Depending on the number of files and their size, the processing may take several minutes to copmlete.";
-      }
-
-      // Display a "success" dialog.
-      return await AlertBuilder.displaySuccess(content, title);
-   }
-
-
-   // Upload the selected files to the web service for processing.
-   async uploadSequences() {
-
-      if (!this.elements.fileInput) { throw new Error("Invalid file control"); }
-      if (!this.elements.fileInput.files || !this.elements.fileInput.files[0]) { throw new Error("Invalid upload file"); }
-      
-      // Get the (optional) job name.
-      let jobName = this.elements.jobName.value;
-      if (!jobName) { jobName = null; }
-
-      try {
-         let filenames = "";
-         let files: IFileData[] = [];
-         let sequenceCount = 0;
-
-         // Iterate over all files
-         for (let f=0; f < this.elements.fileInput.files.length; f++) {
-
-            const file = this.elements.fileInput.files.item(f);
-            if (!file) { continue; }
-
-            // Get the file's contents
-            const contents = await this.readFileAsync(file);
-            if (!contents) { continue; }
-
-            // Update the sequence count with the number of FASTA headers in this file.
-            sequenceCount += (contents.match(/>/g) || []).length;
-
-            if (filenames.length > 0) { filenames += ", "; }
-            filenames += file.name;
-
-            // Add file data to the array.
-            files.push({
-               name: file.name,
-               contents: contents
-            })
-         }
-         
-         if (files.length < 1) { 
-            return await AlertBuilder.displayError("Unable to upload: no valid files were found");
-         }
-
-         if (sequenceCount >= this.MAX_SEQUENCE_COUNT) {    
-            return await AlertBuilder.displayError(`Unable to upload: The maximum number of sequences ` +
-               `that can be loaded is ${this.MAX_SEQUENCE_COUNT} (you tried to submit ${sequenceCount} sequences)`);
-         }
-
-         await Promise.allSettled([
-
-            // Upload the sequence file(s) to the web service for processing.
-            SequenceSearchService.uploadSequences(this.authToken, files, jobName, this.user.email, this.user.uid)
-               .then(job_ => { this.job = job_; }), 
-            
-            // Show a modal dialog with information about the uploaded files.
-            this.showInfoDialog(files.length, filenames)
-         ])
-         .then((results_) => {
-            if (results_[0].status === "rejected") { throw new Error(results_[0].reason); }
-         });
-         
-      } catch (error_) {
-         await AlertBuilder.displayError(error_);
-      }
-
-      // Re-initialize the upload controls.
-      this.elements.fileInput.files = null;
-
-      // Update the upload button.
-      this.elements.uploadButton.innerHTML = `Nothing to submit`;
-
-      // Clear the job name control.
-      this.elements.jobName.value = "";
-
-      // Display the file selection panel.
-      this.elements.fileSelection.classList.add("active");
-
-      // Hide the file submission panel.
-      this.elements.fileSubmission.classList.remove("active");
-
-      // If a job was returned, display it.
-      if (this.job !== null) { await this.displayJob(); }
-
-      return;
-   }
-
-
-   // Display the BLAST HTML data for a specific result.
-   async viewHTML(index_: number) {
-
-      // Get the result with the specified index.
-      const result = this.job.data.results[index_];
-
-      // Open a new tab/window and populate it with the contents of the BLAST HTML file.
-      const blastWindow = window.open("", "_blank");
-
-      // Decode the base64-encoded HTML file and decompress it.
-      const html = pako.inflate(decode(result.html_file), { to: 'string' });
-      blastWindow.document.writeln(html);
-
-      // Remove the extension from the file name and use it as the window's title.
-      blastWindow.document.title = result.blast_html.replace(".html", "");
 
       return;
    }

--- a/ui/src/components/SequenceSearch/UploadPanel.ts
+++ b/ui/src/components/SequenceSearch/UploadPanel.ts
@@ -1,0 +1,304 @@
+
+
+import { AlertBuilder } from "../../helpers/AlertBuilder";
+import { ButtonClass, Constants, Icon, PanelKey } from "./Common";
+import { decode } from "base64-arraybuffer";
+import { IFileData } from "../../models/IFileData";
+import { ISeqSearchPanel } from "./ISeqSearchPanel";
+import { SequenceSearch } from "./SequenceSearch";
+import { SequenceSearchService } from "../../services/SequenceSearchService";
+import * as pako from "pako";
+
+
+export class UploadPanel implements ISeqSearchPanel {
+   
+   config = {
+      acceptedFileTypes: [".fa", ".faa", ".fas", ".fasta", ".ffn", ".fna", ".frn", ".mpfa", ".txt"]
+      //contactEmail: null
+   }
+
+   containerSelector: string;
+
+   // DOM elements
+   elements: {
+      cancelButton: HTMLButtonElement,
+      container: HTMLElement,
+      fileControl: HTMLElement,
+      fileInput: HTMLInputElement,
+      fileSelection: HTMLElement,
+      fileSubmission: HTMLElement,
+      fileUploadDetails: HTMLElement,
+      jobName: HTMLInputElement,
+      jobNameLabel: HTMLElement,
+      uploadButton: HTMLButtonElement
+   }
+
+   // The parent page
+   parent: SequenceSearch = null;
+
+
+   // C-tor
+   constructor(parent_: SequenceSearch) {
+
+      if (!parent_) { throw new Error("Invalid parent parameter"); }
+      this.parent = parent_;
+
+      this.elements = {
+         cancelButton: null,
+         container: null,
+         fileControl: null,
+         fileInput: null,
+         fileSelection: null,
+         fileSubmission: null,
+         fileUploadDetails: null,
+         jobName: null,
+         jobNameLabel: null,
+         uploadButton: null
+      }
+
+   }
+
+
+
+   display() {
+
+      // Create a local copy of the parent's upload container Element.
+      this.elements.container = this.parent.elements.uploadContainer;
+
+      console.log("container = ", this.elements.container) 
+      
+      // Format the accepted file types.
+      let fileFormats = this.config.acceptedFileTypes.join(",");
+
+      // Create HTML for the container Element.
+      const html = 
+         `<div class=\"upload-panel\">
+            <div class="file-selection active">
+               <div class="upload-message">Upload your FASTA sequence(s)</div>
+               <button class=\"btn file-control\">${Icon.browse} Select file(s)</button>
+               <input type=\"file\" id=\"file_input\" multiple accept="${fileFormats}" />
+            </div>
+            <div class="file-submission">
+               <div class=\"job-name-label\">Job name</div>
+               <input type=\"text\" class=\"job-name\" placeholder=\"(optional)\" />
+               <button class=\"btn ${ButtonClass.upload}\">Submit file(s)</button>
+               <button class=\"btn ${ButtonClass.cancel}\">${Icon.cancel} Cancel</button>
+            </div>
+         </div>`;
+
+      this.elements.container.innerHTML = html;
+
+      // Get references to the DOM elements.
+
+      
+      // Get and validate the file selection panel.
+      this.elements.fileSelection = <HTMLElement>this.elements.container.querySelector(".file-selection");
+      if (!this.elements.fileSelection) { throw new Error("Invalid file selection Element"); }
+
+      // Get and validate the file submission panel.
+      this.elements.fileSubmission = <HTMLElement>this.elements.container.querySelector(".file-submission");
+      if (!this.elements.fileSubmission) { throw new Error("Invalid file submission Element"); }  
+
+      // Get and validate the upload button.
+      this.elements.uploadButton = <HTMLButtonElement>this.elements.container.querySelector(`.${ButtonClass.upload}`);
+      if (!this.elements.uploadButton) { throw new Error("Invalid upload button Element"); }
+
+      this.elements.uploadButton.addEventListener("click", () => { this.uploadSequences(); })
+
+      // Get and validate the file input Element.
+      this.elements.fileInput = <HTMLInputElement>this.elements.container.querySelector("#file_input");
+      if (!this.elements.fileInput) { throw new Error("Invalid file input Element"); }
+
+      // Handle a file selection change.
+      this.elements.fileInput.addEventListener("change", async (event_: MouseEvent) => {
+      
+         if (!this.elements.fileInput.files || this.elements.fileInput.files.length < 1) {
+            
+            // Hide the file submission panel.
+            this.elements.fileSubmission.classList.remove("active");
+            return;
+         }
+         
+         // Begin populating the upload button text.
+         let buttonText = `${Icon.upload} Submit`;
+         
+         if (this.elements.fileInput.files.length === 1) {
+            buttonText += " file";
+         } else {
+            buttonText += ` ${this.elements.fileInput.files.length} files`;
+         }
+
+         // Hide the file selection panel.
+         this.elements.fileSelection.classList.remove("active");
+
+         // Display the file submission panel.
+         this.elements.fileSubmission.classList.add("active");
+
+         // Update the upload button text.
+         this.elements.uploadButton.innerHTML = buttonText;
+      })
+
+      this.elements.fileControl = <HTMLElement>this.elements.container.querySelector(".file-control");
+      if (!this.elements.fileControl) { throw new Error("Invalid file control Element"); }
+
+      // Clicking on the file button will trigger a click on the file input element.
+      this.elements.fileControl.addEventListener("click", async (event_: MouseEvent) => {
+         this.elements.fileInput.click();
+      })
+
+      // The job name control and its label.
+      this.elements.jobNameLabel = <HTMLElement>this.elements.container.querySelector(".job-name-label");
+      if (!this.elements.jobNameLabel) { throw new Error("Invalid job name label Element"); }
+
+      this.elements.jobName = <HTMLInputElement>this.elements.container.querySelector(".job-name");
+      if (!this.elements.jobName) { throw new Error("Invalid job name Element"); }
+
+      // The cancel (submission) button
+      this.elements.cancelButton = <HTMLButtonElement>this.elements.container.querySelector(`.${ButtonClass.cancel}`);
+      if (!this.elements.cancelButton) { throw new Error("Invalid cancel button Element"); }
+
+      // Handle the cancel button click event.
+      this.elements.cancelButton.addEventListener("click", (event_: MouseEvent) => {
+
+         // Display the file selection panel again.
+         this.elements.fileSelection.classList.add("active");
+
+         // Hide the file submission panel.
+         this.elements.fileSubmission.classList.remove("active");
+
+         // Clear the file input
+         this.elements.fileInput.value = ""; 
+
+         // Clear the job name input
+         this.elements.jobName.value = ""; 
+      })
+
+
+      // TODO: Wire up event handlers.
+   }
+
+
+   // Read the contents of a file asynchronously and return it as a base64-encoded string.
+   async readFileAsync(file_): Promise<string> {
+
+      return new Promise((resolve, reject) => {
+         const reader = new FileReader();
+         reader.onload = () => {
+            resolve(<string>reader.result);
+         };
+         reader.onerror = reject;
+         reader.readAsText(file_);
+      })
+   }
+
+   // This dialog lets the user know that their files are being processed and what to expect.
+   async showInfoDialog(fileCount_: number, filenames_: string) {
+
+      let content: string;
+      let title: string;
+
+      // The message content depends on the number of files.
+      if (fileCount_ === 1) {
+         title = "Processing your sequence file";
+         content = "Your sequence file has been uploaded. Depending on the size of the file, the processing may take several minutes to copmlete.";
+
+      } else {
+         title = "Processing your sequence files";
+         content = "Your sequence files have been uploaded. Depending on the number of files and their size, the processing may take several minutes to copmlete.";
+      }
+
+      // Display a "success" dialog.
+      return await AlertBuilder.displaySuccess(content, title);
+   }
+
+   unload() {
+
+
+   }
+
+   // Upload the selected files to the web service for processing.
+   async uploadSequences() {
+
+      if (!this.elements.fileInput) { throw new Error("Invalid file control"); }
+      if (!this.elements.fileInput.files || !this.elements.fileInput.files[0]) { throw new Error("Invalid upload file"); }
+      
+      // Get the (optional) job name.
+      let jobName = this.elements.jobName.value;
+      if (!jobName) { jobName = null; }
+
+      try {
+         let filenames = "";
+         let files: IFileData[] = [];
+         let sequenceCount = 0;
+
+         // Iterate over all files
+         for (let f=0; f < this.elements.fileInput.files.length; f++) {
+
+            const file = this.elements.fileInput.files.item(f);
+            if (!file) { continue; }
+
+            // Get the file's contents
+            const contents = await this.readFileAsync(file);
+            if (!contents) { continue; }
+
+            // Update the sequence count with the number of FASTA headers in this file.
+            sequenceCount += (contents.match(/>/g) || []).length;
+
+            if (filenames.length > 0) { filenames += ", "; }
+            filenames += file.name;
+
+            // Add file data to the array.
+            files.push({
+               name: file.name,
+               contents: contents
+            })
+         }
+         
+         if (files.length < 1) { 
+            return await AlertBuilder.displayError("Unable to upload: no valid files were found");
+         }
+
+         if (sequenceCount >= Constants.MAX_SEQUENCE_COUNT) {    
+            return await AlertBuilder.displayError(`Unable to upload: The maximum number of sequences ` +
+               `that can be loaded is ${Constants.MAX_SEQUENCE_COUNT} (you tried to submit ${sequenceCount} sequences)`);
+         }
+
+         await Promise.allSettled([
+
+            // Upload the sequence file(s) to the web service for processing.
+            SequenceSearchService.uploadSequences(this.parent.authToken, files, jobName, this.parent.user.email, this.parent.user.uid)
+               .then(job_ => { this.parent.job = job_; }), 
+            
+            // Show a modal dialog with information about the uploaded files.
+            this.showInfoDialog(files.length, filenames)
+         ])
+         .then((results_) => {
+            if (results_[0].status === "rejected") { throw new Error(results_[0].reason); }
+         });
+         
+      } catch (error_) {
+         await AlertBuilder.displayError(error_);
+      }
+
+      // Re-initialize the upload controls.
+      this.elements.fileInput.files = null;
+
+      // Update the upload button.
+      this.elements.uploadButton.innerHTML = `Nothing to submit`;
+
+      // Clear the job name control.
+      this.elements.jobName.value = "";
+
+      // Display the file selection panel.
+      this.elements.fileSelection.classList.add("active");
+
+      // Hide the file submission panel.
+      this.elements.fileSubmission.classList.remove("active");
+
+      // If a job was returned, display it.
+      //if (this.job !== null) { await this.displayJob(); }
+
+      return;
+   }
+
+}

--- a/ui/src/components/TaxonHistory/TaxonHistory.ts
+++ b/ui/src/components/TaxonHistory/TaxonHistory.ts
@@ -400,7 +400,7 @@ export class TaxonHistory {
       }
 
       // Moved (don't include if the lineage has been updated, as well)
-      if (taxon_.isMoved && !taxon_.isLineageUpdated) {
+      if (taxon_.isMoved /*&& !taxon_.isLineageUpdated*/) {
 
          let formattedPrevParent = "";
          
@@ -536,19 +536,24 @@ export class TaxonHistory {
 
          let displayLabel = filename_;
 
-         const periodIndex = displayLabel.lastIndexOf(".");
-         if (periodIndex > 0) { displayLabel = filename_.substring(0, periodIndex); }
-
-         // Get an icon class specific to the file type.
-         const iconClass = this.getFileIconClass(filename_);
-
          // Separate multiple links with a line break.
          if (proposalLinks.length > 0) { proposalLinks += "<br/>"; }
 
-         // Add a link to the release proposal file(s).
-         proposalLinks += `<i class="${iconClass}" aria-hidden="true"></i>
-            <a href="${AppSettings.releaseProposalsURL}${filename_}" target="_blank" rel="noopener noreferrer" 
-            class="release-proposal-link">${displayLabel}</a>`;   
+         const periodIndex = displayLabel.lastIndexOf(".");
+         if (periodIndex > 0) { 
+
+            displayLabel = filename_.substring(0, periodIndex); 
+         
+            // Get an icon class specific to the file type.
+            const iconClass = this.getFileIconClass(filename_);
+
+            // Add a link to the release proposal file(s).
+            proposalLinks += `<i class="${iconClass}" aria-hidden="true"></i>
+               <a href="${AppSettings.releaseProposalsURL}${filename_}" target="_blank" rel="noopener noreferrer" 
+               class="release-proposal-link">${displayLabel}</a>`;
+         } else {
+            proposalLinks += displayLabel;
+         }
       })
    
       if (proposalLinks.length < 1) { return ""; }


### PR DESCRIPTION
- Changed taxNodeID parameter in GetTaxonHistory.sql from IN to OUT.
- Updated SeqSearch service code (temporarily) to remove "tax_out/" from filenames in tax_results.json.
- Now treating FASTA files as text files instead of binary.
- Updated the taxon history Typescript to 1) simultaneously display "moved" and "lineage updated" if a taxon has both, and 2) if a proposal filename doesn't have a file extension, it is displayed as text instead of a link (this is mostly for the proposals with the text "missing" instead of a file name).
- The SeqSearch UI now has separate panel objects for the 3 display modes: upload files, display job, and display BLAST hits.